### PR TITLE
Implement onboarding pager and sensors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(platform("androidx.compose:compose-bom:2024.05.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 

--- a/app/src/main/java/com/example/paddel/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/example/paddel/onboarding/OnboardingScreen.kt
@@ -1,14 +1,58 @@
 package com.example.paddel.onboarding
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun OnboardingScreen(onFinished: () -> Unit) {
-    Box(Modifier.fillMaxSize()) {
-        Text("Onboarding placeholder")
+    val pages = listOf(
+        "Welcome to PaddleRoute",
+        "Allow location permission to track your trips",
+        "Use the map screen to plan and record your paddles"
+    )
+    val pagerState = rememberPagerState(pageCount = { pages.size })
+    val scope = rememberCoroutineScope()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(pages[page], style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            val lastPage = pages.size - 1
+            Button(onClick = {
+                if (pagerState.currentPage == lastPage) {
+                    onFinished()
+                } else {
+                    scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) }
+                }
+            }) {
+                Text(if (pagerState.currentPage == lastPage) "Done" else "Next")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/paddel/safety/SafetyService.kt
+++ b/app/src/main/java/com/example/paddel/safety/SafetyService.kt
@@ -1,7 +1,77 @@
 package com.example.paddel.safety
 
+import android.util.Log
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
 import javax.inject.Inject
 
+/**
+ * Service responsible for fetching basic wind and water information from SMHI's
+ * open data APIs.  The method is intentionally lightweight and merely returns a
+ * pair of values representing the latest available wind speed and water level
+ * for the supplied position.
+ */
 class SafetyService @Inject constructor() {
-    fun fetchSmhiData() { /* TODO */ }
+
+    data class SmhiData(val windSpeed: Double?, val waterLevel: Double?)
+
+    /**
+     * Fetch the current wind and water data for the provided coordinates.  The
+     * implementation uses simple blocking network calls and the built-in JSON
+     * parser so that no extra dependencies are required.
+     */
+    fun fetchSmhiData(lat: Double, lon: Double): SmhiData {
+        val wind = try {
+            val forecastUrl =
+                "https://opendata.smhi.se/api/category/pmp3g/version/2/geotype/point/lon/$lon/lat/$lat/data.json"
+            val json = httpGet(forecastUrl)
+            parseWind(json)
+        } catch (e: Exception) {
+            Log.w("SafetyService", "Failed to load wind data", e)
+            null
+        }
+
+        val water = try {
+            // Example station for water level, real apps should choose nearest
+            val stationUrl =
+                "https://opendata.smhi.se/api/category/hydrography/version/1.0/parameter/wa/station/1200/period/latest-months/data.json"
+            val json = httpGet(stationUrl)
+            parseWater(json)
+        } catch (e: Exception) {
+            Log.w("SafetyService", "Failed to load water data", e)
+            null
+        }
+
+        return SmhiData(wind, water)
+    }
+
+    private fun httpGet(url: String): String {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.connectTimeout = 10_000
+        connection.readTimeout = 10_000
+        return connection.inputStream.bufferedReader().use { it.readText() }
+    }
+
+    private fun parseWind(json: String): Double? {
+        val root = JSONObject(json)
+        val timeSeries = root.getJSONArray("timeSeries")
+        if (timeSeries.length() == 0) return null
+        val first = timeSeries.getJSONObject(0)
+        val params = first.getJSONArray("parameters")
+        for (i in 0 until params.length()) {
+            val p = params.getJSONObject(i)
+            if (p.getString("name") == "ws") {
+                return p.getJSONArray("values").getDouble(0)
+            }
+        }
+        return null
+    }
+
+    private fun parseWater(json: String): Double? {
+        val root = JSONObject(json)
+        val values = root.getJSONArray("value")
+        if (values.length() == 0) return null
+        return values.getJSONObject(0).getDouble("value")
+    }
 }

--- a/app/src/main/java/com/example/paddel/training/StrokeAnalyzer.kt
+++ b/app/src/main/java/com/example/paddel/training/StrokeAnalyzer.kt
@@ -1,7 +1,61 @@
 package com.example.paddel.training
 
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlin.math.pow
+import kotlin.math.sqrt
 
-class StrokeAnalyzer @Inject constructor() {
-    fun analyze() { /* TODO */ }
+/**
+ * Very small helper that registers a listener on the linear acceleration
+ * sensor and keeps track of detected paddle strokes.  A stroke is counted when
+ * the measured acceleration exceeds a threshold and enough time has passed
+ * since the last detected stroke.  The algorithm is intentionally simple but
+ * serves to demonstrate how motion sensor input could be processed.
+ */
+class StrokeAnalyzer @Inject constructor(
+    @ApplicationContext context: Context
+) : SensorEventListener {
+
+    private val sensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+    var strokeCount: Int = 0
+        private set
+
+    private var lastPeakTime: Long = 0
+
+    /** Threshold for acceleration magnitude to be considered a stroke. */
+    private val threshold = 11f
+
+    /**
+     * Start analysing paddle strokes.  Each time a stroke is detected the
+     * [strokeCount] property is incremented.  Callers may poll this property or
+     * extend the class to provide callbacks when a new stroke is registered.
+     */
+    fun analyze() {
+        sensorManager.getDefaultSensor(Sensor.TYPE_LINEAR_ACCELERATION)?.let {
+            sensorManager.registerListener(this, it, SensorManager.SENSOR_DELAY_GAME)
+        }
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        event ?: return
+        val magnitude = sqrt(
+            event.values[0].pow(2) + event.values[1].pow(2) + event.values[2].pow(2)
+        )
+        val now = System.currentTimeMillis()
+        if (magnitude > threshold && now - lastPeakTime > 300) {
+            strokeCount++
+            lastPeakTime = now
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // No-op
+    }
 }


### PR DESCRIPTION
## Summary
- fetch wind and water info from SMHI in `SafetyService`
- analyze acceleration events in `StrokeAnalyzer`
- replace onboarding placeholder with a simple pager
- add compose foundation dependency

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591a70bd208328974c4a6beca8f929