### PR TITLE
Enable AndroidX & Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and jetifier in Gradle

## Testing
- `gradle :app:dependencies --configuration debugRuntimeClasspath`


------
https://chatgpt.com/codex/tasks/task_e_685951846970832890c1690ac1a5c834